### PR TITLE
Pass applicable config options to alpm and provide a method for ignorepkg checking

### DIFF
--- a/alpm_test.go
+++ b/alpm_test.go
@@ -31,7 +31,7 @@ func init() {
 func ExampleVersion() {
 	fmt.Println(Version())
 	// output:
-	// 8.0.2
+	// 10.0.2
 }
 
 func ExampleVerCmp() {

--- a/conf.go
+++ b/conf.go
@@ -336,5 +336,13 @@ func (conf *PacmanConfig) CreateHandle() (*Handle, error) {
 
 	C.alpm_option_set_deltaratio(h.ptr, C.double(conf.UseDelta))
 
+	if (conf.Options & ConfUseSyslog) > 0 {
+		C.alpm_option_set_usesyslog(h.ptr, 1)
+	}
+
+	if (conf.Options & ConfCheckSpace) > 0 {
+		C.alpm_option_set_checkspace(h.ptr, 1)
+	}
+
 	return h, nil
 }

--- a/conf.go
+++ b/conf.go
@@ -6,9 +6,6 @@
 
 package alpm
 
-//#include <alpm.h>
-import "C"
-
 import (
 	"bufio"
 	"bytes"
@@ -249,7 +246,7 @@ lineloop:
 					*fieldP = strings.Join(line.Values, " ")
 				case *[]string:
 					//many valued option.
-					*fieldP = append(*fieldP, line.Values...)
+					*fieldP = line.Values
 				}
 			}
 		}
@@ -259,6 +256,17 @@ lineloop:
 func (conf *PacmanConfig) SetDefaults() {
 	conf.RootDir = "/"
 	conf.DBPath = "/var/lib/pacman"
+	conf.DBPath = "/var/lib/pacman/"
+	conf.CacheDir = []string{"/var/cache/pacman/pkg/"}
+	conf.HookDir = []string{"/etc/pacman.d/hooks/"}
+	conf.GPGDir = "/etc/pacman.d/gnupg/"
+	conf.LogFile = "/var/log/pacman.log"
+	conf.UseDelta = 0.7
+	conf.CleanMethod = "KeepInstalled"
+
+	conf.SigLevel = SigPackage | SigPackageOptional | SigDatabase | SigDatabaseOptional
+	conf.LocalFileSigLevel = SigUseDefault
+	conf.RemoteFileSigLevel = SigUseDefault
 }
 
 func getArch() (string, error) {

--- a/conf_test.go
+++ b/conf_test.go
@@ -22,7 +22,7 @@ var pacmanConfRef = PacmanConfig{
 	XferCommand:  "/usr/bin/wget --passive-ftp -c -O %o %u",
 	Architecture: "auto",
 	CleanMethod:  "KeepInstalled",
-	UseDelta:     "0.7",
+	UseDelta:     0.7,
 	IgnorePkg:    []string{"hello", "world"},
 	IgnoreGroup:  []string{"kde"},
 	NoUpgrade:    nil,

--- a/handle.go
+++ b/handle.go
@@ -12,6 +12,8 @@
 package alpm
 
 // #include <alpm.h>
+// #include <stdio.h> //C.free
+// #include <fnmatch.h> //C.FNM_NOMATCH
 import "C"
 
 import (
@@ -25,11 +27,12 @@ type Handle struct {
 // Initialize
 func Init(root, dbpath string) (*Handle, error) {
 	c_root := C.CString(root)
-	defer C.free(unsafe.Pointer(c_root))
 	c_dbpath := C.CString(dbpath)
-	defer C.free(unsafe.Pointer(c_dbpath))
 	var c_err C.alpm_errno_t
 	h := C.alpm_initialize(c_root, c_dbpath, &c_err)
+
+	defer C.free(unsafe.Pointer(c_root))
+	defer C.free(unsafe.Pointer(c_dbpath))
 
 	if c_err != 0 {
 		return nil, Error(c_err)
@@ -46,14 +49,6 @@ func (h *Handle) Release() error {
 	return nil
 }
 
-func (h Handle) Root() string {
-	return C.GoString(C.alpm_option_get_root(h.ptr))
-}
-
-func (h Handle) DbPath() string {
-	return C.GoString(C.alpm_option_get_dbpath(h.ptr))
-}
-
 // LastError gets the last pm_error
 func (h Handle) LastError() error {
 	if h.ptr != nil {
@@ -65,19 +60,522 @@ func (h Handle) LastError() error {
 	return nil
 }
 
-func (h Handle) UseSyslog() bool {
-	value := C.alpm_option_get_usesyslog(h.ptr)
-	return (value != 0)
+//
+//alpm options getters and setters
+//
+
+//helper functions for wrapping list_t getters and setters
+func (h Handle) optionGetList(f func(*C.alpm_handle_t) *C.alpm_list_t) (StringList, error){
+	alpmList := f(h.ptr)
+	goList := StringList{(*list)(unsafe.Pointer(alpmList))}
+
+	if alpmList == nil {
+		return goList, h.LastError()
+	}
+	return goList, nil
+}
+
+
+func (h Handle) optionSetList(hookDirs []string, f func(*C.alpm_handle_t, *C.alpm_list_t) C.int) error {
+	var list *C.alpm_list_t = nil
+
+	for _, dir := range hookDirs {
+		c_dir := C.CString(dir)
+		list = C.alpm_list_add(list, unsafe.Pointer(c_dir))
+		defer C.free(unsafe.Pointer(c_dir))
+	}
+
+	ok := f(h.ptr, list)
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+}
+
+func (h Handle) optionAddList(hookDir string, f func(*C.alpm_handle_t, *C.char) C.int) error {
+	c_hookdir := C.CString(hookDir)
+	defer C.free(unsafe.Pointer(c_hookdir))
+	ok := f(h.ptr, c_hookdir)
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+}
+
+func (h Handle) optionRemoveList(dir string, f func(*C.alpm_handle_t, *C.char) C.int) (bool, error) {
+	c_dir := C.CString(dir)
+	ok := f(h.ptr, c_dir)
+	defer C.free(unsafe.Pointer(c_dir))
+	if ok < 0 {
+		return ok == 1, h.LastError()
+	}
+	return ok == 1, nil
+}
+
+func (h Handle) optionMatchList(dir string, f func(*C.alpm_handle_t, *C.char) C.int) (bool, error) {
+	c_dir := C.CString(dir)
+	ok := f(h.ptr, c_dir)
+	defer C.free(unsafe.Pointer(c_dir))
+	if ok == 0 {
+		return true, nil
+	} else if ok == C.FNM_NOMATCH {
+		return false, h.LastError()
+	}
+	return false, nil
+}
+
+//helper functions for *char based getters and setters
+func (h Handle) optionGetStr(f func(*C.alpm_handle_t) *C.char) (string, error) {
+	c_str := f(h.ptr)
+	str := C.GoString(c_str)
+	if c_str == nil {
+		return str, h.LastError()
+	}
+
+	return str, nil
+}
+
+func (h Handle) optionSetStr(str string, f func(*C.alpm_handle_t, *C.char) C.int) error {
+	c_str := C.CString(str)
+	defer C.free(unsafe.Pointer(c_str))
+	ok := f(h.ptr, c_str)
+
+	if ok < 0 {
+		 h.LastError()
+	}
+	return  nil
+}
+
+//
+//end of helpers
+//
+
+func (h Handle) Root() (string, error) {
+	return h.optionGetStr(func(handle *C.alpm_handle_t) *C.char {
+		return C.alpm_option_get_root(handle)
+	})
+}
+
+func (h Handle) DBPath() (string, error) {
+	return h.optionGetStr(func(handle *C.alpm_handle_t) *C.char {
+		return C.alpm_option_get_dbpath(handle)
+	})
+}
+
+func (h Handle) Lockfile() (string, error) {
+	return h.optionGetStr(func(handle *C.alpm_handle_t) *C.char {
+		return C.alpm_option_get_lockfile(handle)
+	})
+}
+
+
+func (h Handle) CacheDirs() (StringList, error) {
+	return h.optionGetList(func(handle *C.alpm_handle_t) *C.alpm_list_t {
+		return C.alpm_option_get_cachedirs(handle)
+	})
+}
+
+func (h Handle) AddCacheDir(hookDir string) error {
+	return h.optionAddList(hookDir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_add_cachedir(handle, str)
+	})
+}
+
+func (h Handle) SetCacheDirs(hookDirs ...string) error {
+	return h.optionSetList(hookDirs, func(handle *C.alpm_handle_t, l *C.alpm_list_t) C.int {
+		return C.alpm_option_set_cachedirs(handle, l)
+	})
+}
+
+func (h Handle) RemoveCacheDir(dir string) (bool, error) {
+	return h.optionRemoveList(dir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_remove_cachedir(handle, str)
+	})
+}
+
+func (h Handle) HookDirs() (StringList, error) {
+	return h.optionGetList(func(handle *C.alpm_handle_t) *C.alpm_list_t {
+		return C.alpm_option_get_hookdirs(handle)
+	})
+}
+
+func (h Handle) AddHookDir(hookDir string) error {
+	return h.optionAddList(hookDir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_add_hookdir(handle, str)
+	})
+}
+
+func (h Handle) SetHookDirs(hookDirs ...string) error {
+	return h.optionSetList(hookDirs, func(handle *C.alpm_handle_t, l *C.alpm_list_t) C.int {
+		return C.alpm_option_set_hookdirs(handle, l)
+	})
+}
+
+func (h Handle) RemoveHookDir(dir string) (bool, error) {
+	return h.optionRemoveList(dir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_remove_hookdir(handle, str)
+	})
+}
+
+func (h Handle) LogFile() (string, error) {
+	return h.optionGetStr(func(handle *C.alpm_handle_t) *C.char {
+		return C.alpm_option_get_logfile(handle)
+	})
+}
+
+func (h Handle) SetLogFile(str string) error {
+	return h.optionSetStr(str, func(handle *C.alpm_handle_t, c_str *C.char) C.int {
+		return C.alpm_option_set_logfile(handle, c_str)
+	})
+}
+
+func (h Handle) GPGDir() (string, error) {
+	return h.optionGetStr(func(handle *C.alpm_handle_t) *C.char {
+		return C.alpm_option_get_gpgdir(handle)
+	})
+}
+
+func (h Handle) SetGPGDir(str string) error {
+	return h.optionSetStr(str, func(handle *C.alpm_handle_t, c_str *C.char) C.int {
+		return C.alpm_option_set_gpgdir(handle, c_str)
+	})
+}
+
+func (h Handle) UseSyslog() (bool, error) {
+	ok := C.alpm_option_get_usesyslog(h.ptr)
+	b := false
+
+	if ok > 0 {
+		b = true
+	}
+	if ok < 0 {
+		return b, h.LastError()
+	}
+	return b, nil
 }
 
 func (h Handle) SetUseSyslog(value bool) error {
-	var int_value C.int
+	var int_value C.int = 0
 	if value {
 		int_value = 1
-	} else {
-		int_value = 0
 	}
+
 	ok := C.alpm_option_set_usesyslog(h.ptr, int_value)
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+}
+
+func (h Handle) NoUpgrades() (StringList, error) {
+	return h.optionGetList(func(handle *C.alpm_handle_t) *C.alpm_list_t {
+		return C.alpm_option_get_noupgrades(handle)
+	})
+}
+
+func (h Handle) AddNoUpgrade(hookDir string) error {
+	return h.optionAddList(hookDir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_add_noupgrade(handle, str)
+	})
+}
+
+func (h Handle) SetNoUpgrades(hookDirs ...string) error {
+	return h.optionSetList(hookDirs, func(handle *C.alpm_handle_t, l *C.alpm_list_t) C.int {
+		return C.alpm_option_set_noupgrades(handle, l)
+	})
+}
+
+func (h Handle) RemoveNoUpgrade(dir string) (bool, error) {
+	return h.optionRemoveList(dir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_remove_noupgrade(handle, str)
+	})
+}
+
+func (h Handle) MatchNoUpgrade(dir string) (bool, error) {
+	return h.optionMatchList(dir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_match_noupgrade(handle, str)
+	})
+}
+
+func (h Handle) NoExtracts() (StringList, error) {
+	return h.optionGetList(func(handle *C.alpm_handle_t) *C.alpm_list_t {
+		return C.alpm_option_get_noextracts(handle)
+	})
+}
+
+func (h Handle) AddNoExtract(hookDir string) error {
+	return h.optionAddList(hookDir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_add_noextract(handle, str)
+	})
+}
+
+func (h Handle) SetNoExtracts(hookDirs ...string) error {
+	return h.optionSetList(hookDirs, func(handle *C.alpm_handle_t, l *C.alpm_list_t) C.int {
+		return C.alpm_option_set_noextracts(handle, l)
+	})
+}
+
+func (h Handle) RemoveNoExtract(dir string) (bool, error) {
+	return h.optionRemoveList(dir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_remove_noextract(handle, str)
+	})
+}
+
+func (h Handle) MatchNoExtract(dir string) (bool, error) {
+	return h.optionMatchList(dir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_match_noextract(handle, str)
+	})
+}
+
+func (h Handle) IgnorePkgs() (StringList, error) {
+	return h.optionGetList(func(handle *C.alpm_handle_t) *C.alpm_list_t {
+		return C.alpm_option_get_ignorepkgs(handle)
+	})
+}
+
+func (h Handle) AddIgnorePkg(hookDir string) error {
+	return h.optionAddList(hookDir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_add_ignorepkg(handle, str)
+	})
+}
+
+func (h Handle) SetIgnorePkgs(hookDirs ...string) error {
+	return h.optionSetList(hookDirs, func(handle *C.alpm_handle_t, l *C.alpm_list_t) C.int {
+		return C.alpm_option_set_ignorepkgs(handle, l)
+	})
+}
+
+func (h Handle) RemoveIgnorePkg(dir string) (bool, error) {
+	return h.optionRemoveList(dir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_remove_ignorepkg(handle, str)
+	})
+}
+
+func (h Handle) IgnoreGroups() (StringList, error) {
+	return h.optionGetList(func(handle *C.alpm_handle_t) *C.alpm_list_t {
+		return C.alpm_option_get_ignoregroups(handle)
+	})
+}
+
+func (h Handle) AddIgnoreGroup(hookDir string) error {
+	return h.optionAddList(hookDir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_add_ignoregroup(handle, str)
+	})
+}
+
+func (h Handle) SetIgnoreGroups(hookDirs ...string) error {
+	return h.optionSetList(hookDirs, func(handle *C.alpm_handle_t, l *C.alpm_list_t) C.int {
+		return C.alpm_option_set_ignoregroups(handle, l)
+	})
+}
+
+func (h Handle) RemoveIgnoreGroup(dir string) (bool, error) {
+	return h.optionRemoveList(dir, func(handle *C.alpm_handle_t, str *C.char) C.int {
+		return C.alpm_option_remove_ignoregroup(handle, str)
+	})
+}
+
+/*func (h Handle) optionGetList(f func(*C.alpm_handle_t) *C.alpm_list_t) (StringList, error){
+	alpmList := f(h.ptr)
+	goList := StringList{(*list)(unsafe.Pointer(alpmList))}
+
+	if alpmList == nil {
+		return goList, h.LastError()
+	}
+	return goList, nil
+}*/
+
+//use alpm_depend_t
+func (h Handle) AssumeInstalled() (DependList, error) {
+	alpmList := C.alpm_option_get_assumeinstalled(h.ptr)
+	depList := DependList{(*list)(unsafe.Pointer(alpmList))}
+
+	if alpmList == nil {
+		return depList, h.LastError()
+	}
+	return depList, nil
+}
+
+func (h Handle) AddAssumeInstalled(dep Depend) error {
+	c_dep := convertCDepend(dep)
+	defer freeCDepend(c_dep)
+
+	ok := C.alpm_option_add_assumeinstalled(h.ptr, c_dep)
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+}
+
+func (h Handle) SetAssumeInstalled(deps ...Depend) error {
+	//calling this function the first time causes alpm to set the
+	//assumeinstalled list to a list containing go allocated alpm_depend_t's
+	//this is bad because alpm might at some point tree to free them
+	//i believe this is whats causing this function to misbhave
+	//although i am not 100% sure
+	//maybe using C.malloc to make the struct could fix the problem
+	//pacamn does not use alpm_option_set_assumeinstalled in its source
+	//code so anybody using this should beable to do file without it
+	//although for the sake of completeness it would be nice to have this
+	//working
+	panic("This function (SetAssumeInstalled) does not work properly, please do not use. See source code for more details")
+	var list *C.alpm_list_t = nil
+
+	for _, dep := range deps {
+		c_dep := convertCDepend(dep)
+		defer freeCDepend(c_dep)
+		list = C.alpm_list_add(list, unsafe.Pointer(c_dep))
+	}
+
+	ok := C.alpm_option_set_assumeinstalled(h.ptr, list)
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+
+}
+
+func (h Handle) RemoveAssumeInstalled(dep Depend) (bool, error) {
+	//internally alpm uses alpm_list_remove to remove a alpm_depend_t from
+	//the list
+	//i believe this function considers items equal if they are the same
+	//item in memeory, not just the same data
+	//every time we convert a go Depend to a alpm_depend_c we create a new
+	//instance of a alpm_depend_c
+	//this means that if you add a Depend using AddAssumeInstalled then try
+	//to remove it using the same Depend c will consider them different
+	//items and not remove them
+	//pacamn does not use alpm_option_set_assumeinstalled in its source
+	//code so anybody using this should beable to do file without it
+	//although for the sake of completeness it would be nice to have this
+	//working
+	panic("This function (RemoveAssumeInstalled) does not work properly, please do not use. See source code for more details")
+	c_dep := convertCDepend(dep)
+	defer freeCDepend(c_dep)
+
+	ok := C.alpm_option_remove_assumeinstalled(h.ptr, c_dep)
+	if ok < 0 {
+		return ok == 1, h.LastError()
+	}
+	return ok == 1, nil
+}
+
+func (h Handle) Arch() (string, error) {
+	return h.optionGetStr(func(handle *C.alpm_handle_t) *C.char {
+		return C.alpm_option_get_arch(handle)
+	})
+}
+
+func (h Handle) SetArch(str string) error {
+	return h.optionSetStr(str, func(handle *C.alpm_handle_t, c_str *C.char) C.int {
+		return C.alpm_option_set_arch(handle, c_str)
+	})
+}
+
+
+func (h Handle) DeltaRatio() (float64, error) {
+	ok := C.alpm_option_get_deltaratio(h.ptr)
+	if ok < 0 {
+		return float64(ok), h.LastError()
+	}
+	return float64(ok), nil
+}
+
+func (h Handle) SetDeltaRatio(ratio float64) error {
+	ok := C.alpm_option_set_deltaratio(h.ptr, C.double(ratio))
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+}
+
+
+func (h Handle) CheckSpace() (bool, error) {
+	ok := C.alpm_option_get_checkspace(h.ptr)
+	b := false
+
+	if ok > 0 {
+		b = true
+	}
+	if ok < 0 {
+		return b, h.LastError()
+	}
+	return b, nil
+}
+
+func (h Handle) SetCheckSpace(value bool) error {
+	var int_value C.int = 0
+	if value {
+		int_value = 1
+	}
+
+	ok := C.alpm_option_set_checkspace(h.ptr, int_value)
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+}
+
+func (h Handle) DBExt() (string, error) {
+	return h.optionGetStr(func(handle *C.alpm_handle_t) *C.char {
+		return C.alpm_option_get_dbext(handle)
+	})
+}
+
+func (h Handle) SetDBExt(str string) error {
+	return h.optionSetStr(str, func(handle *C.alpm_handle_t, c_str *C.char) C.int {
+		return C.alpm_option_set_dbext(handle, c_str)
+	})
+}
+
+func (h Handle) GetDefaultSigLevel() (SigLevel, error) {
+	sigLevel := C.alpm_option_get_default_siglevel(h.ptr)
+
+	if sigLevel < 0 {
+		return SigLevel(sigLevel), h.LastError()
+	}
+	return SigLevel(sigLevel), nil
+}
+
+func (h Handle) SetDefaultSigLevel(siglevel SigLevel) error {
+	ok := C.alpm_option_set_default_siglevel(h.ptr, C.alpm_siglevel_t(siglevel))
+	
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+}
+
+func (h Handle) GetLocalFileSigLevel() (SigLevel, error) {
+	sigLevel := C.alpm_option_get_local_file_siglevel(h.ptr)
+
+	if sigLevel < 0 {
+		return SigLevel(sigLevel), h.LastError()
+	}
+	return SigLevel(sigLevel), nil
+}
+
+func (h Handle) SetLocalFileSigLevel(siglevel SigLevel) error {
+	ok := C.alpm_option_set_local_file_siglevel(h.ptr, C.alpm_siglevel_t(siglevel))
+	
+	if ok < 0 {
+		return h.LastError()
+	}
+	return nil
+}
+
+func (h Handle) GetRemoteFileSigLevel() (SigLevel, error) {
+	sigLevel := C.alpm_option_get_remote_file_siglevel(h.ptr)
+
+	if sigLevel < 0 {
+		return SigLevel(sigLevel), h.LastError()
+	}
+	return SigLevel(sigLevel), nil
+}
+
+func (h Handle) SetRemoteFileSigLevel(siglevel SigLevel) error {
+	ok := C.alpm_option_set_remote_file_siglevel(h.ptr, C.alpm_siglevel_t(siglevel))
+
 	if ok < 0 {
 		return h.LastError()
 	}

--- a/package.go
+++ b/package.go
@@ -244,3 +244,8 @@ func (pkg Package) NewVersion(l DbList) *Package {
 	}
 	return &Package{ptr, l.handle}
 }
+
+func (pkg Package) ShouldIgnore() bool {
+	result := C.alpm_pkg_should_ignore(pkg.handle.ptr, pkg.pmpkg)
+	return result == 1
+}

--- a/package_test.go
+++ b/package_test.go
@@ -79,11 +79,13 @@ func TestPkginfo(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	pkginfo_tpl.Execute(buf, PrettyPackage{*pkg})
 	t.Logf("%s...", buf.Bytes()[:1024])
+	t.Logf("Should ignore %t", pkg.ShouldIgnore())
 
 	pkg, _ = db.PkgByName("linux")
 	if pkg != nil {
 		buf = bytes.NewBuffer(nil)
 		pkginfo_tpl.Execute(buf, PrettyPackage{*pkg})
 		t.Logf("%s...", buf.Bytes()[:1024])
+		t.Logf("Should ignore %t", pkg.ShouldIgnore())
 	}
 }


### PR DESCRIPTION
This is a fix for Jguer/yay#71.

ShouldIgnore should replace (or be wrapped by) isIgnored in yay for changes to take effect. 