### PR TITLE
Add question enum

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -96,3 +96,15 @@ const (
 	LogDebug
 	LogFunction
 )
+
+type Question uint
+
+const (
+	QuestionInstallIgnorepkg Question = 1 << iota
+	QuestionReplacePkg
+	QuestionConflictPkg
+	QuestionCorruptedPkg
+	QuestionRemovePkgs
+	QuestionSelectProvider
+	QuestionImportKey
+)


### PR DESCRIPTION
This allows easier manipulation of --ask when passing to pacman. This
serves no internal purpose as I only added the actual enum. The C calls
and structs can be added later if needed.