### PR TITLE
Add support for question callback

### DIFF
--- a/callbacks.c
+++ b/callbacks.c
@@ -10,6 +10,7 @@
 #include <alpm.h>
 
 void logCallback(uint16_t level, char *cstring);
+void questionCallback(alpm_question_t *question);
 
 void go_alpm_log_cb(alpm_loglevel_t level, const char *fmt, va_list arg) {
   char *s = malloc(128);
@@ -25,7 +26,14 @@ void go_alpm_log_cb(alpm_loglevel_t level, const char *fmt, va_list arg) {
   }
 }
 
-void go_alpm_set_logging(alpm_handle_t *handle) {
-  alpm_option_set_logcb(handle, go_alpm_log_cb);
+void go_alpm_question_cb(alpm_question_t *question) {
+	questionCallback(question);
 }
 
+void go_alpm_set_logging(alpm_handle_t *handle) {
+	alpm_option_set_logcb(handle, go_alpm_log_cb);
+}
+
+void go_alpm_set_question(alpm_handle_t *handle) {
+	alpm_option_set_questioncb(handle, go_alpm_question_cb);
+}

--- a/enums.go
+++ b/enums.go
@@ -97,16 +97,16 @@ const (
 	LogFunction
 )
 
-type Question uint
+type QuestionType uint
 
 const (
-	QuestionInstallIgnorepkg Question = 1 << iota
-	QuestionReplacePkg
-	QuestionConflictPkg
-	QuestionCorruptedPkg
-	QuestionRemovePkgs
-	QuestionSelectProvider
-	QuestionImportKey
+	QuestionTypeInstallIgnorepkg QuestionType = 1 << iota
+	QuestionTypeReplacePkg
+	QuestionTypeConflictPkg
+	QuestionTypeCorruptedPkg
+	QuestionTypeRemovePkgs
+	QuestionTypeSelectProvider
+	QuestionTypeImportKey
 )
 
 type Validation int

--- a/types.go
+++ b/types.go
@@ -13,6 +13,7 @@ import "C"
 import (
 	"reflect"
 	"unsafe"
+	"fmt"
 )
 
 // Description of a dependency.
@@ -149,4 +150,100 @@ func (l BackupList) Slice() (slice []BackupFile) {
 		return nil
 	})
 	return
+}
+
+type QuestionAny struct {
+	ptr *C.alpm_question_any_t
+}
+
+func (question QuestionAny) SetAnswer(answer bool) {
+	if answer {
+		question.ptr.answer = 1
+	} else {
+		question.ptr.answer = 0
+	}
+}
+
+type QuestionInstallIgnorepkg struct {
+	ptr *C.alpm_question_install_ignorepkg_t
+}
+
+func (question QuestionAny) Type() QuestionType{
+	return QuestionType(question.ptr._type)
+}
+
+func (question QuestionAny) Answer() bool {
+	return question.ptr.answer == 1
+}
+
+func (question QuestionAny) QuestionInstallIgnorepkg() (QuestionInstallIgnorepkg, error) {
+	if question.Type() == QuestionTypeInstallIgnorepkg {
+		return *(*QuestionInstallIgnorepkg)(unsafe.Pointer(&question)), nil
+	}
+
+	return QuestionInstallIgnorepkg{}, fmt.Errorf("Can not convert to QuestionInstallIgnorepkg")
+}
+
+func (question QuestionInstallIgnorepkg) SetInstall(install bool) {
+	if install {
+		question.ptr.install = 1
+	} else {
+		question.ptr.install = 0
+	}
+}
+
+func (question QuestionInstallIgnorepkg) Type() QuestionType {
+	return QuestionType(question.ptr._type)
+}
+
+func (question QuestionInstallIgnorepkg) Install() bool {
+	return question.ptr.install == 1
+}
+
+func (question QuestionInstallIgnorepkg) Pkg(h *Handle) Package {
+	return Package {
+		question.ptr.pkg,
+		*h,
+	}
+}
+
+type QuestionReplace struct {
+	ptr *C.alpm_question_replace_t
+}
+
+func (question QuestionReplace) Type() QuestionType {
+	return QuestionType(question.ptr._type)
+}
+
+func (question QuestionReplace) SetReplace(replace bool) {
+	if replace {
+		question.ptr.replace = 1
+	} else {
+		question.ptr.replace = 0
+	}
+}
+
+func (question QuestionReplace) Replace() bool {
+	return  question.ptr.replace == 1
+}
+
+func (question QuestionReplace) NewPkg(h *Handle) Package {
+	return Package {
+		question.ptr.newpkg,
+		*h,
+	}
+}
+
+func (question QuestionReplace) OldPkg(h *Handle) Package {
+	return Package {
+		question.ptr.oldpkg,
+		*h,
+	}
+}
+
+func (question QuestionReplace) newDb(h *Handle) Db {
+	return Db {
+		question.ptr.newdb,
+		*h,
+	}
 }


### PR DESCRIPTION
Not all callback types are implemented as that would require defining
a lot of different types. The main purpose of this is to use the
ignorepkg question. If others are needed they can be added later.

The existing Question enmum and its values have all been named to
QuestionType, anything using these values will need to change them to
the name Name.