### PR TITLE
Update for Pacman 5.1

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -114,18 +114,14 @@ func (rdr *confReader) ParseLine() (tok iniToken, err error) {
 	rdr.Lineno++
 
 	line = bytes.TrimSpace(line)
-
-	comment := bytes.IndexByte(line, '#')
-	if comment >= 0 {
-		line = line[:comment]
-	}
-
 	if len(line) == 0 {
 		tok.Type = tokenComment
 		return
 	}
-
 	switch line[0] {
+	case '#':
+		tok.Type = tokenComment
+		return
 	case '[':
 		closing := bytes.IndexByte(line, ']')
 		if closing < 0 {

--- a/db.go
+++ b/db.go
@@ -89,7 +89,7 @@ func (h Handle) RegisterSyncDb(dbname string, siglevel SigLevel) (*Db, error) {
 	cName := C.CString(dbname)
 	defer C.free(unsafe.Pointer(cName))
 
-	db := C.alpm_register_syncdb(h.ptr, cName, C.alpm_siglevel_t(siglevel))
+	db := C.alpm_register_syncdb(h.ptr, cName, C.int(siglevel))
 	if db == nil {
 		return nil, h.LastError()
 	}

--- a/enums.go
+++ b/enums.go
@@ -62,7 +62,7 @@ func (mod DepMod) String() string {
 }
 
 // Signature checking level.
-type SigLevel uint
+type SigLevel int
 
 const (
 	SigPackage SigLevel = 1 << iota
@@ -79,7 +79,7 @@ const (
 const SigUseDefault SigLevel = 1 << 31
 
 // Signature status
-type SigStatus uint
+type SigStatus int
 
 const (
 	SigStatusValid SigStatus = iota

--- a/handle.go
+++ b/handle.go
@@ -534,7 +534,7 @@ func (h Handle) GetDefaultSigLevel() (SigLevel, error) {
 }
 
 func (h Handle) SetDefaultSigLevel(siglevel SigLevel) error {
-	ok := C.alpm_option_set_default_siglevel(h.ptr, C.alpm_siglevel_t(siglevel))
+	ok := C.alpm_option_set_default_siglevel(h.ptr, C.int(siglevel))
 
 	if ok < 0 {
 		return h.LastError()
@@ -552,7 +552,7 @@ func (h Handle) GetLocalFileSigLevel() (SigLevel, error) {
 }
 
 func (h Handle) SetLocalFileSigLevel(siglevel SigLevel) error {
-	ok := C.alpm_option_set_local_file_siglevel(h.ptr, C.alpm_siglevel_t(siglevel))
+	ok := C.alpm_option_set_local_file_siglevel(h.ptr, C.int(siglevel))
 
 	if ok < 0 {
 		return h.LastError()
@@ -570,7 +570,7 @@ func (h Handle) GetRemoteFileSigLevel() (SigLevel, error) {
 }
 
 func (h Handle) SetRemoteFileSigLevel(siglevel SigLevel) error {
-	ok := C.alpm_option_set_remote_file_siglevel(h.ptr, C.alpm_siglevel_t(siglevel))
+	ok := C.alpm_option_set_remote_file_siglevel(h.ptr, C.int(siglevel))
 
 	if ok < 0 {
 		return h.LastError()

--- a/package.go
+++ b/package.go
@@ -159,18 +159,16 @@ func (pkg Package) OptionalDepends() DependList {
 }
 
 // Depends returns the package's check dependency list.
-//Exists in futre alpm
-/*func (pkg Package) CheckDepends() DependList {
+func (pkg Package) CheckDepends() DependList {
 	ptr := unsafe.Pointer(C.alpm_pkg_get_checkdepends(pkg.pmpkg))
 	return DependList{(*list)(ptr)}
-}*/
+}
 
 // Depends returns the package's make dependency list.
-//Exists in futre alpm
-/*func (pkg Package) MakeDepends() DependList {
+func (pkg Package) MakeDepends() DependList {
 	ptr := unsafe.Pointer(C.alpm_pkg_get_makedepends(pkg.pmpkg))
 	return DependList{(*list)(ptr)}
-}*/
+}
 
 // Description returns the package's description.
 func (pkg Package) Description() string {


### PR DESCRIPTION
Fixes so this can be built against the new alpm release. Installing a couple of packages with Yay built against this seems to work fine.

The PKGBUILD should have a versioned dependency on pacman>=5.1