### PR TITLE
fix SigUseDefault to match ALPM_SIG_USE_DEFAULT

### DIFF
--- a/enums.go
+++ b/enums.go
@@ -76,7 +76,7 @@ const (
 	SigDatabaseMarginalOk
 	SigDatabaseUnknownOk
 )
-const SigUseDefault SigLevel = 1 << 31
+const SigUseDefault SigLevel = 1 << 30
 
 // Signature status
 type SigStatus int


### PR DESCRIPTION
This reflects upstream's new value for this constant (see
https://git.archlinux.org/pacman.git/tree/lib/libalpm/alpm.h#n207)
which is necessary to prevent an overflow on 32-bit builds (rarer though
they may be).