### PR TITLE
Update function name for next pacman release

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -29,7 +29,7 @@ func (l DBList) FindGroupPkgs(name string) PackageList {
 
 // NewVersion checks if there is a new version of the package in a given DBlist.
 func (pkg *Package) SyncNewVersion(l DBList) *Package {
-	ptr := C.alpm_sync_newversion(pkg.pmpkg,
+	ptr := C.alpm_sync_get_new_version(pkg.pmpkg,
 		(*C.alpm_list_t)(unsafe.Pointer(l.List)))
 	if ptr == nil {
 		return nil


### PR DESCRIPTION
I'm not quite sure on the function name on the go side. We follow go's conventions and just use .Foo instead of .GetFoo so `SyncNewVersion` makes sense. 

However the name might suggest that it actually syncs the new version, where it actually just gets the new package data from the database. This is now apparent from the c function name but not from the go function name

Also the function implementation has slightly changed. The point of the rename is to be a breaking change, making it obvious for downstream users to know there was a change. So would it also back sense for us to rename it too?

It's not that big a deal though, I'm fine with it as if there's no better name suggested. Just worth mentioning.