### PR TITLE
Add functions for adding/removing packages

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -1,5 +1,8 @@
 package alpm
 
+// #include <alpm.h>
+import "C"
+
 import (
 	"time"
 )
@@ -76,6 +79,9 @@ type IPackage interface {
 	SyncNewVersion(l IDBList) IPackage
 
 	Type() string
+
+	// Get the underlying alpm pkg type
+	getPmpkg() *C.alpm_pkg_t
 }
 
 // IPackageList exports the alpm.PackageList symbols.

--- a/package.go
+++ b/package.go
@@ -303,6 +303,10 @@ func (pkg *Package) Type() string {
 	return "alpm"
 }
 
+func (pkg *Package) getPmpkg() *C.alpm_pkg_t {
+	return pkg.pmpkg
+}
+
 // SortBySize returns a PackageList sorted by size.
 func (l PackageList) SortBySize() IPackageList {
 	pkgList := (*C.struct__alpm_list_t)(unsafe.Pointer(l.list))

--- a/testdata/examples/Makefile
+++ b/testdata/examples/Makefile
@@ -1,4 +1,4 @@
-all: alpm-installed alpm-search alpm-updates
+all: alpm-installed alpm-search alpm-updates alpm-sync
 
 alpm-installed: installed.go
 	go build -x -o $@ $<
@@ -7,6 +7,9 @@ alpm-search: search.go
 	go build -x -o $@ $<
 
 alpm-updates: updates.go
+	go build -x -o $@ $<
+
+alpm-sync: sync.go
 	go build -x -o $@ $<
 
 clean:

--- a/testdata/examples/sync/sync.go
+++ b/testdata/examples/sync/sync.go
@@ -1,0 +1,111 @@
+// sync.go - Example of installing, and removing packages.
+//
+// Copyright (c) 2013 The go-alpm Authors
+//
+// MIT Licensed. See LICENSE for details.
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Jguer/go-alpm/v2"
+	"github.com/Morganamilo/go-pacmanconf"
+)
+
+func main() {
+	h, err := alpm.Initialize("/", "/var/lib/pacman")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	defer func() {
+		if err := h.Release(); err != nil {
+			fmt.Println(err)
+			return
+		}
+	}()
+
+	conf, _, err := pacmanconf.ParseFile("/etc/pacman.conf")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("loading databases")
+
+	var addPkg alpm.IPackage
+	var removePkg alpm.IPackage
+
+	for _, repo := range conf.Repos {
+		db, err := h.RegisterSyncDB(repo.Name, 0)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		db.SetServers(repo.Servers)
+
+		foundPkg := db.Pkg("vim")
+		if foundPkg != nil {
+			addPkg = foundPkg
+		}
+	}
+
+	localDb, err := h.LocalDB()
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	// A package can only be removed if it is in the local DB
+	removePkg = localDb.Pkg("vi")
+
+	fmt.Println("initializing transaction")
+	if err := h.TransInit(0); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	defer func() {
+		fmt.Println("releasing transaction")
+		if err := h.TransRelease(); err != nil {
+			fmt.Println(err)
+			return
+		}
+	}()
+
+	fmt.Println("synchronizing databases")
+	if err := h.SyncSysupgrade(true); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("adding package")
+	if err := h.AddPkg(addPkg); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("removing package")
+	if removePkg != nil {
+		if err := h.RemovePkg(removePkg); err != nil {
+			fmt.Println(err)
+			return
+		}
+	} else {
+		fmt.Println("vi is not installed")
+	}
+
+	fmt.Println("preparing transaction")
+	if err := h.TransPrepare(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	fmt.Println("committing transaction")
+	if err := h.TransCommit(); err != nil {
+		fmt.Println(err)
+		return
+	}
+}

--- a/trans.go
+++ b/trans.go
@@ -24,6 +24,34 @@ func (h *Handle) TransInit(flags TransFlag) error {
 	return nil
 }
 
+func (h *Handle) TransPrepare() error {
+	var data *C.alpm_list_t
+	ret := C.alpm_trans_prepare(h.ptr, &data)
+	if ret != 0 {
+		return h.LastError()
+	}
+
+	return nil
+}
+
+func (h *Handle) TransInterrupt() error {
+	ret := C.alpm_trans_interrupt(h.ptr)
+	if ret != 0 {
+		return h.LastError()
+	}
+
+	return nil
+}
+
+func (h *Handle) TransCommit() error {
+	ret := C.alpm_trans_commit(h.ptr, nil)
+	if ret != 0 {
+		return h.LastError()
+	}
+
+	return nil
+}
+
 func (h *Handle) TransRelease() error {
 	ret := C.alpm_trans_release(h.ptr)
 	if ret != 0 {
@@ -51,4 +79,22 @@ func (h *Handle) TransGetFlags() (TransFlag, error) {
 	}
 
 	return TransFlag(flags), nil
+}
+
+func (h *Handle) AddPkg(pkg IPackage) error {
+	ret := C.alpm_add_pkg(h.ptr, pkg.getPmpkg())
+	if ret != 0 {
+		return h.LastError()
+	}
+
+	return nil
+}
+
+func (h *Handle) RemovePkg(pkg IPackage) error {
+	ret := C.alpm_remove_pkg(h.ptr, pkg.getPmpkg())
+	if ret != 0 {
+		return h.LastError()
+	}
+
+	return nil
 }


### PR DESCRIPTION
Hello, I want to use go-alpm for a hobby project, but I see that there's no support for package adding/removing.

This PR adds support for the following functions:
- alpm_trans_prepare
- alpm_trans_interrupt
- alpm_trans_commit
- alpm_add_pkg
- alpm_remove_pkg

I also added minimal example in `testdata/examples/sync/sync.go` (not sure if the name is appropriate).
I did not include `alpm_trans_interrupt` call in the example, because I do not fully understand how it works internally, and when it can be called.