### PR TITLE
fix(go-alpm): add checks around nil pointers in Pkgcache

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# Use the jguer/yay-builder image as a parent image with archlinux
+FROM docker.io/jguer/yay-builder
+
+# Install extra packages (pacman-contrib and fish)
+RUN sudo pacman -Syu --noconfirm pacman-contrib fish git-delta openssh bat go
+
+# Set passwordless sudo for the docker user
+RUN echo "docker ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/docker
+
+# Create a non-root user and switch to it
+USER docker
+
+# Set the working directory
+WORKDIR /workspace
+
+# Command to run when starting the container
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		"context": "..",
+		"dockerfile": "../.devcontainer/Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go"
+			]
+		}
+	}
+}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
     - dupl
     - errorlint
     - errcheck
-    - exportloopref
+    - copyloopvar
     # - funlen # TOFIX
     - gochecknoinits
     # - goconst # TOFIX

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ WORKDIR /app
 COPY go.mod .
 
 RUN pacman -Syu --overwrite=* --needed --noconfirm go && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2 && \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.1.5 && \
     go mod download && \
     rm -rfv /var/cache/pacman/* /var/lib/pacman/sync/*

--- a/alpm_test.go
+++ b/alpm_test.go
@@ -35,7 +35,7 @@ func TestRevdeps(t *testing.T) {
 	db, _ := h.LocalDB()
 	pkg := db.Pkg("glibc")
 	for i, pkgname := range pkg.ComputeRequiredBy() {
-		t.Logf(pkgname)
+		t.Log(pkgname)
 		if i == 10 {
 			t.Logf("and %d more...", len(pkg.ComputeRequiredBy())-10)
 			return

--- a/db.go
+++ b/db.go
@@ -180,8 +180,10 @@ func (db *DB) Pkg(name string) IPackage {
 
 // PkgCache returns the list of packages of the database
 func (db *DB) PkgCache() IPackageList {
+	if db == nil || db.ptr == nil {
+		return PackageList{nil, db.handle}
+	}
 	pkgcache := (*list)(unsafe.Pointer(C.alpm_db_get_pkgcache(db.ptr)))
-
 	return PackageList{pkgcache, db.handle}
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,254 @@
+package alpm
+
+import (
+	"os"
+	"testing"
+)
+
+func getTestAlpmHandle(t *testing.T) *Handle {
+	// Try to use environment variables for test root/dbpath, or fallback to system defaults
+	root := os.Getenv("ALPM_TEST_ROOT")
+	if root == "" {
+		root = "/"
+	}
+	dbpath := os.Getenv("ALPM_TEST_DBPATH")
+	if dbpath == "" {
+		dbpath = "/var/lib/pacman/"
+	}
+
+	h, err := Initialize(root, dbpath)
+	if err != nil {
+		t.Skipf("Could not initialize alpm: %v", err)
+	}
+	return h
+}
+
+func TestHandle_RegisterSyncDB_and_SyncDBByName(t *testing.T) {
+	h := getTestAlpmHandle(t)
+	defer h.Release()
+
+	dbName := "core" // This should exist on most Arch systems
+	db, err := h.RegisterSyncDB(dbName, 0)
+	if err != nil {
+		t.Fatalf("RegisterSyncDB failed: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("RegisterSyncDB returned nil DB")
+	}
+
+	found, err := h.SyncDBByName(dbName)
+	if err != nil {
+		t.Fatalf("SyncDBByName failed: %v", err)
+	}
+	if found == nil {
+		t.Fatalf("SyncDBByName returned nil DB")
+	}
+	if found.Name() != dbName {
+		t.Errorf("Expected DB name %q, got %q", dbName, found.Name())
+	}
+}
+
+func TestHandle_UnregisterAllSyncDBs(t *testing.T) {
+	h := getTestAlpmHandle(t)
+	defer h.Release()
+
+	dbName := "core"
+	_, err := h.RegisterSyncDB(dbName, 0)
+	if err != nil {
+		t.Fatalf("RegisterSyncDB failed: %v", err)
+	}
+
+	err = h.UnregisterAllSyncDBs()
+	if err != nil {
+		t.Fatalf("UnregisterAllSyncDBs failed: %v", err)
+	}
+}
+
+// --- DB methods ---
+
+func TestDB_Search(t *testing.T) {
+	h := getTestAlpmHandle(t)
+	defer h.Release()
+
+	db, err := h.RegisterSyncDB("core", 0)
+	if err != nil {
+		t.Skipf("RegisterSyncDB failed: %v", err)
+	}
+
+	// Search for a common package
+	target := "bash"
+	pkgs := db.Search([]string{target})
+	if pkgs == nil {
+		t.Fatalf("Search returned nil for target %q", target)
+	}
+	slice := pkgs.Slice()
+	if len(slice) == 0 {
+		t.Errorf("Expected at least one package for target %q, got 0", target)
+	}
+	found := false
+	for _, pkg := range slice {
+		if pkg != nil && pkg.Name() == target {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Did not find package with name %q in search results", target)
+	}
+
+	// Search for a non-existent package
+	nonexistent := "thispackagedoesnotexist12345"
+	none := db.Search([]string{nonexistent})
+	if none == nil {
+		t.Fatalf("Search returned nil for non-existent target")
+	}
+	if len(none.Slice()) != 0 {
+		t.Errorf("Expected 0 results for non-existent package, got %d", len(none.Slice()))
+	}
+}
+
+func TestDB_AddServer(t *testing.T) {
+	h := getTestAlpmHandle(t)
+	defer h.Release()
+
+	db, err := h.RegisterSyncDB("core", 0)
+	if err != nil {
+		t.Skipf("RegisterSyncDB failed: %v", err)
+	}
+
+	server := "http://example.com/$repo/os/$arch"
+	db.AddServer(server)
+
+	servers := db.Servers()
+	found := false
+	for _, s := range servers {
+		if s == server {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Server %q not found in DB server list: %v", server, servers)
+	}
+}
+
+// --- DBList group method ---
+
+func TestDBList_Slice_Empty(t *testing.T) {
+	var dblist DBList // nil list
+	slice := dblist.Slice()
+	if len(slice) != 0 {
+		t.Errorf("Expected empty slice, got %d elements", len(slice))
+	}
+}
+
+func TestDBList_ForEach_and_Slice_NonEmpty(t *testing.T) {
+	h := getTestAlpmHandle(t)
+	defer h.Release()
+
+	dblist, err := h.SyncDBs()
+	if err != nil {
+		t.Fatalf("SyncDBs failed: %v", err)
+	}
+
+	var count int
+	names := make(map[string]bool)
+	err = dblist.ForEach(func(db IDB) error {
+		count++
+		name := db.Name()
+		names[name] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEach failed: %v", err)
+	}
+
+	slice := dblist.Slice()
+	if len(slice) != count {
+		t.Errorf("Slice length %d does not match ForEach count %d", len(slice), count)
+	}
+	for _, db := range slice {
+		if !names[db.Name()] {
+			t.Errorf("DB %q in slice not found in ForEach names", db.Name())
+		}
+	}
+}
+
+func TestDBList_Append(t *testing.T) {
+	h := getTestAlpmHandle(t)
+	defer h.Release()
+
+	db, err := h.RegisterSyncDB("core", 0)
+	if err != nil {
+		t.Skipf("RegisterSyncDB failed: %v", err)
+	}
+
+	dblist := h.NewDBList()
+	if dblist == nil {
+		t.Fatalf("NewDBList returned nil")
+	}
+
+	// Should be empty initially
+	slice := dblist.Slice()
+	if len(slice) != 0 {
+		t.Errorf("Expected empty slice, got %d elements", len(slice))
+	}
+
+	dblist.Append(db)
+	slice = dblist.Slice()
+	if len(slice) != 1 {
+		t.Errorf("Expected slice of length 1 after append, got %d", len(slice))
+	}
+	if slice[0].Name() != "core" {
+		t.Errorf("Expected DB name 'core', got %q", slice[0].Name())
+	}
+}
+
+func TestDBList_FindGroupPkgs(t *testing.T) {
+	h := getTestAlpmHandle(t)
+	defer h.Release()
+
+	dblist, err := h.SyncDBs()
+	if err != nil {
+		t.Fatalf("SyncDBs failed: %v", err)
+	}
+
+	group := "base" // Common group in Arch
+	pkgs := dblist.FindGroupPkgs(group)
+	if pkgs == nil {
+		t.Fatalf("FindGroupPkgs returned nil for group %q", group)
+	}
+	// We can't guarantee the group exists, but we can check that the call succeeded
+}
+
+func TestHandle_SyncDBListByDBName(t *testing.T) {
+	h := getTestAlpmHandle(t)
+	defer h.Release()
+
+	dbName := "core"
+	_, err := h.RegisterSyncDB(dbName, 0)
+	if err != nil {
+		t.Skipf("RegisterSyncDB failed: %v", err)
+	}
+
+	dblist, err := h.SyncDBListByDBName(dbName)
+	if err != nil {
+		t.Fatalf("SyncDBListByDBName failed: %v", err)
+	}
+	if dblist == nil {
+		t.Fatalf("SyncDBListByDBName returned nil list")
+	}
+	slice := dblist.Slice()
+	if len(slice) != 1 {
+		t.Errorf("Expected list of length 1, got %d", len(slice))
+	}
+	if slice[0].Name() != dbName {
+		t.Errorf("Expected DB name %q, got %q", dbName, slice[0].Name())
+	}
+
+	// Negative case
+	_, err = h.SyncDBListByDBName("doesnotexist123")
+	if err == nil {
+		t.Errorf("Expected error for non-existent DB name, got nil")
+	}
+}

--- a/db_test.go
+++ b/db_test.go
@@ -75,13 +75,18 @@ func TestDB_Search(t *testing.T) {
 		t.Skipf("RegisterSyncDB failed: %v", err)
 	}
 
-	// Search for a common package
-	target := "bash"
-	pkgs := db.Search([]string{target})
-	if pkgs == nil {
+	// Dynamically pick a package name from the sync DB
+	pkgs := db.PkgCache().Slice()
+	if len(pkgs) == 0 {
+		t.Skip("No packages found in the sync DB; skipping test")
+	}
+	target := pkgs[0].Name()
+
+	searchResults := db.Search([]string{target})
+	if searchResults == nil {
 		t.Fatalf("Search returned nil for target %q", target)
 	}
-	slice := pkgs.Slice()
+	slice := searchResults.Slice()
 	if len(slice) == 0 {
 		t.Errorf("Expected at least one package for target %q, got 0", target)
 	}

--- a/deps_test.go
+++ b/deps_test.go
@@ -1,0 +1,76 @@
+package alpm_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	alpm "github.com/Jguer/go-alpm/v2"
+)
+
+func TestDBList_FindSatisfier(t *testing.T) {
+	h, err := alpm.Initialize("/", "/var/lib/pacman")
+	defer h.Release()
+	if err != nil {
+		t.Fatalf("Failed to initialize alpm: %v", err)
+	}
+
+	dblist, err := h.SyncDBs()
+	if err != nil {
+		t.Fatalf("Failed to get sync DBs: %v", err)
+	}
+
+	// Dynamically pick a package name from the sync DBs
+	var foundPkgName string
+	for _, db := range dblist.Slice() {
+		pkgs := db.PkgCache().Slice()
+		if len(pkgs) > 0 {
+			foundPkgName = pkgs[0].Name()
+			break
+		}
+	}
+	if foundPkgName == "" {
+		t.Skip("No packages found in sync DBs")
+	}
+
+	// Test a dependency that should exist
+	pkg, err := dblist.FindSatisfier(foundPkgName)
+	assert.NoError(t, err)
+	assert.NotNil(t, pkg)
+	if pkg != nil {
+		assert.Equal(t, foundPkgName, pkg.Name())
+	}
+
+	// Test a dependency that should not exist
+	pkg, err = dblist.FindSatisfier("thispackagedoesnotexist>=1.0")
+	assert.Error(t, err)
+	assert.Nil(t, pkg)
+}
+
+func TestPackageList_FindSatisfier(t *testing.T) {
+	h, err := alpm.Initialize("/", "/var/lib/pacman")
+	defer h.Release()
+	if err != nil {
+		t.Fatalf("Failed to initialize alpm: %v", err)
+	}
+
+	db, err := h.LocalDB()
+	if err != nil {
+		t.Fatalf("Failed to get local DB: %v", err)
+	}
+
+	pkglist := db.PkgCache()
+
+	// Test a dependency that should exist
+	pkg, err := pkglist.FindSatisfier("glibc>=2.12")
+	assert.NoError(t, err)
+	assert.NotNil(t, pkg)
+	if pkg != nil {
+		assert.Equal(t, "glibc", pkg.Name())
+	}
+
+	// Test a dependency that should not exist
+	pkg, err = pkglist.FindSatisfier("thispackagedoesnotexist>=1.0")
+	assert.Error(t, err)
+	assert.Nil(t, pkg)
+}

--- a/package_test.go
+++ b/package_test.go
@@ -67,21 +67,16 @@ func TestPkginfo(t *testing.T) {
 		t.Errorf("Failed at alpm initialization: %s", er)
 	}
 
-	t.Log("Printing package information for pacman")
 	db, _ := h.LocalDB()
 
 	pkg := db.Pkg("glibc")
 	buf := bytes.NewBuffer(nil)
 	pkginfoTemp.Execute(buf, PrettyPackage{pkg.(*alpm.Package)})
-	t.Logf("%s...", buf.Bytes()[:1024])
-	t.Logf("Should ignore %t", pkg.ShouldIgnore())
 
 	pkg = db.Pkg("linux")
 	if pkg != nil {
 		buf = bytes.NewBuffer(nil)
 		pkginfoTemp.Execute(buf, PrettyPackage{pkg.(*alpm.Package)})
-		t.Logf("%s...", buf.Bytes()[:1024])
-		t.Logf("Should ignore %t", pkg.ShouldIgnore())
 	}
 }
 


### PR DESCRIPTION


### Development Environment Updates:
* Added a `Dockerfile` in `.devcontainer` to set up a development container with Arch Linux, pre-installed tools (e.g., `fish`, `git-delta`, `bat`), and a non-root user configuration. (`.devcontainer/Dockerfile`)
* Added a `devcontainer.json` file to configure the development container, specifying the `Dockerfile` and installing the `golang.go` VS Code extension. (`.devcontainer/devcontainer.json`)

### Code Improvements:
* Updated the `PkgCache` method in `db.go` to handle `nil` database pointers gracefully, returning an empty `PackageList` instead of causing a potential crash. (`db.go`)
* Simplified logging in the `TestRevdeps` function by replacing `t.Logf` with `t.Log` for non-formatted strings. (`alpm_test.go`)

### Test Enhancements:
* Added comprehensive tests in `db_test.go` to cover database operations, including registering/unregistering sync databases, searching for packages, and managing database lists. (`db_test.go`)
* Introduced new tests in `deps_test.go` to validate dependency resolution using `FindSatisfier` for both database lists and package lists. (`deps_test.go`)